### PR TITLE
fix xdg-open crash in ncw-web-demo container

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig(({ command, mode }) => {
     base: "/ncw-web-demo/",
     plugins: [react(), splitVendorChunkPlugin()],
     server: {
-      open: true,
+      open: false,
       host: 'localhost',
       port: (env.VITE_PORT && Number(env.VITE_PORT)) || 5173,
       hmr: true,


### PR DESCRIPTION
## **Description:**

The Dockerized EW demo has 4 containers, but one container (ncw-web-demo) crashes due to an issue with the xdg-open command. This happens when the Vite app tries to open the browser automatically after building, causing the following error:
 
2024-11-20 15:15:56 Error: spawn xdg-open ENOENT
2024-11-20 15:15:56     at ChildProcess._handle.onexit (node:internal/child_process:283:19)
2024-11-20 15:15:56     at onErrorNT (node:internal/child_process:476:16)
2024-11-20 15:15:56     at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
2024-11-20 15:15:56 Emitted 'error' event on ChildProcess instance at:
2024-11-20 15:15:56     at ChildProcess._handle.onexit (node:internal/child_process:289:12)
2024-11-20 15:15:56     at onErrorNT (node:internal/child_process:476:16)
2024-11-20 15:15:56     at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
2024-11-20 15:15:56   errno: -2,
2024-11-20 15:15:56   code: 'ENOENT',
2024-11-20 15:15:56   syscall: 'spawn xdg-open',
2024-11-20 15:15:56   path: 'xdg-open',
2024-11-20 15:15:56   spawnargs: [ 'http://localhost:5173/ncw-web-demo/' ]



## Solution
Modified vite.config.ts: The open option in the Vite configuration was set to false to prevent the Vite app from attempting to automatically open the browser during the build process.